### PR TITLE
GitHub Actions更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -34,7 +34,7 @@ jobs:
           FIREBASE_TOKEN: ${{ vars.FIREBASE_TOKEN }}
 
       - name: Upload Archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: yamacraft-cv
           path: public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           args: deploy --only hosting
         env:
-          FIREBASE_TOKEN: ${{ vars.FIREBASE_TOKEN }}
+          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_YAMACRAFT_CV }}
 
       - name: Upload Archive
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- コンテナのUbuntuをlatestに変更
- actionsのバージョンを更新
  - checkoutをv3からv4へ
  - setup-nodeをv3からv4へ
    - nodeバージョンは2025.04までサポート続くので、18のままで
  - upload-artifactをv1からv4へ